### PR TITLE
feat: implement bot control panel and command center

### DIFF
--- a/src/hooks/use-guilds.ts
+++ b/src/hooks/use-guilds.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { PlayInGuildInput } from "@/types/api";
+import {
+  getGuilds,
+  getGuildStatus,
+  playInGuild,
+  stopInGuild,
+  stopAll,
+} from "@/services/guild-service";
+
+export const guildKeys = {
+  all: ["guilds"] as const,
+  list: () => [...guildKeys.all, "list"] as const,
+  detail: (guildId: string) => [...guildKeys.all, "detail", guildId] as const,
+};
+
+export function useGuilds() {
+  return useQuery({
+    queryKey: guildKeys.list(),
+    queryFn: getGuilds,
+    refetchInterval: 10_000,
+  });
+}
+
+export function useGuildStatus(guildId: string) {
+  return useQuery({
+    queryKey: guildKeys.detail(guildId),
+    queryFn: () => getGuildStatus(guildId),
+    enabled: !!guildId,
+  });
+}
+
+export function usePlayInGuild() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ guildId, input }: { guildId: string; input: PlayInGuildInput }) =>
+      playInGuild(guildId, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: guildKeys.all });
+    },
+  });
+}
+
+export function useStopInGuild() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (guildId: string) => stopInGuild(guildId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: guildKeys.all });
+    },
+  });
+}
+
+export function useStopAll() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => stopAll(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: guildKeys.all });
+    },
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+
+  return parts.join(" ");
+}

--- a/src/pages/dashboard/controls.tsx
+++ b/src/pages/dashboard/controls.tsx
@@ -1,10 +1,398 @@
-export default function ControlsPage() {
+import { useState, useMemo } from "react";
+import {
+  Server,
+  Headphones,
+  Radio,
+  Square,
+  Play,
+  Search,
+  Volume2,
+  Zap,
+  AlertTriangle,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGuilds, usePlayInGuild, useStopInGuild, useStopAll } from "@/hooks/use-guilds";
+import { useStations } from "@/hooks/use-stations";
+import type { GuildStatus } from "@/types/api";
+
+function GuildInitials({ name }: { name: string }) {
+  const initials = name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
   return (
-    <div className="space-y-4">
-      <h1 className="text-3xl font-bold">Controls</h1>
-      <p className="text-muted-foreground">
-        Bot controls — play, pause, skip, and adjust volume.
-      </p>
+    <div className="w-14 h-14 rounded-lg bg-zinc-800 flex items-center justify-center text-zinc-300 font-bold border border-zinc-700 text-sm">
+      {initials}
+    </div>
+  );
+}
+
+function GuildIcon({ guild }: { guild: GuildStatus }) {
+  if (guild.iconUrl) {
+    return (
+      <div className="w-14 h-14 rounded-lg overflow-hidden border border-zinc-700">
+        <img
+          src={guild.iconUrl}
+          alt={guild.name}
+          className="w-full h-full object-cover opacity-80"
+        />
+      </div>
+    );
+  }
+  return <GuildInitials name={guild.name} />;
+}
+
+function ActiveConnectionCard({ guild }: { guild: GuildStatus }) {
+  const stopMutation = useStopInGuild();
+
+  return (
+    <div className="bg-[#18181b] border border-zinc-800 rounded-lg p-5 flex flex-col sm:flex-row sm:items-center gap-5 hover:border-zinc-600 transition-all group">
+      <div className="relative shrink-0">
+        <GuildIcon guild={guild} />
+        <div className="absolute -bottom-1 -right-1 bg-black rounded-full p-0.5">
+          <div className="bg-emerald-500 text-[8px] text-black font-bold px-1.5 rounded-full uppercase tracking-wider">
+            Live
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <h3 className="font-bold text-white truncate text-sm">{guild.name}</h3>
+        </div>
+        <div className="flex items-center gap-4 text-xs text-zinc-400">
+          <span className="flex items-center gap-1.5 truncate">
+            <Volume2 className="w-3.5 h-3.5" />
+            <span>{guild.audio.channelName ?? "Unknown"}</span>
+          </span>
+          <span className="w-1 h-1 bg-zinc-700 rounded-full" />
+          <span className="flex items-center gap-1.5 text-emerald-400">
+            <Radio className="w-3.5 h-3.5" />
+            <span className="truncate">{guild.audio.currentStation?.name ?? "Unknown"}</span>
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 sm:border-l sm:border-zinc-800 sm:pl-4">
+        <div className="text-right">
+          <div className="flex items-center justify-end gap-1 text-white font-bold text-sm">
+            <span>{guild.audio.listenerCount}</span>
+            <Headphones className="w-3.5 h-3.5 text-zinc-500" />
+          </div>
+          <span className="text-[10px] text-zinc-500 uppercase tracking-wide">Listeners</span>
+        </div>
+        <button
+          onClick={() => stopMutation.mutate(guild.guildId)}
+          disabled={stopMutation.isPending}
+          className="bg-zinc-900 hover:bg-red-900/30 text-zinc-400 hover:text-red-400 border border-zinc-700 hover:border-red-800 p-2 rounded transition-colors disabled:opacity-50"
+        >
+          <Square className="w-5 h-5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function StatsCards({ guilds }: { guilds: GuildStatus[] }) {
+  const totalGuilds = guilds.length;
+  const activeStreams = guilds.filter((g) => g.audio.isPlaying).length;
+  const totalListeners = guilds.reduce((sum, g) => sum + g.audio.listenerCount, 0);
+
+  return (
+    <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+      <div className="bg-[#18181b] border border-zinc-800 rounded-lg p-6 flex items-center justify-between group hover:border-zinc-600 transition-colors">
+        <div>
+          <span className="text-[10px] text-zinc-500 uppercase tracking-widest font-bold block mb-1">
+            Total Guilds
+          </span>
+          <span className="text-3xl font-bold text-white tracking-tighter">{totalGuilds}</span>
+        </div>
+        <div className="w-10 h-10 rounded bg-zinc-900 flex items-center justify-center text-zinc-500 group-hover:text-white transition-colors">
+          <Server className="w-5 h-5" />
+        </div>
+      </div>
+
+      <div className="bg-[#18181b] border border-zinc-800 rounded-lg p-6 flex items-center justify-between group hover:border-zinc-600 transition-colors relative overflow-hidden">
+        {activeStreams > 0 && (
+          <div className="absolute top-0 right-0 p-2">
+            <span className="flex h-3 w-3 relative">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500" />
+            </span>
+          </div>
+        )}
+        <div>
+          <span className="text-[10px] text-zinc-500 uppercase tracking-widest font-bold block mb-1">
+            Active Streams
+          </span>
+          <span className="text-3xl font-bold text-white tracking-tighter">{activeStreams}</span>
+        </div>
+        <div className="w-10 h-10 rounded bg-emerald-900/20 flex items-center justify-center text-emerald-500">
+          <Radio className="w-5 h-5" />
+        </div>
+      </div>
+
+      <div className="bg-[#18181b] border border-zinc-800 rounded-lg p-6 flex items-center justify-between group hover:border-zinc-600 transition-colors">
+        <div>
+          <span className="text-[10px] text-zinc-500 uppercase tracking-widest font-bold block mb-1">
+            Total Listeners
+          </span>
+          <span className="text-3xl font-bold text-white tracking-tighter">
+            {totalListeners.toLocaleString()}
+          </span>
+        </div>
+        <div className="w-10 h-10 rounded bg-zinc-900 flex items-center justify-center text-zinc-500 group-hover:text-white transition-colors">
+          <Headphones className="w-5 h-5" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function QuickPlaySidebar({ guilds }: { guilds: GuildStatus[] }) {
+  const [selectedGuildId, setSelectedGuildId] = useState("");
+  const [selectedChannelId, setSelectedChannelId] = useState("");
+  const [selectedStationId, setSelectedStationId] = useState("");
+  const { data: stations } = useStations();
+  const playMutation = usePlayInGuild();
+  const stopAllMutation = useStopAll();
+
+  const selectedGuild = guilds.find((g) => g.guildId === selectedGuildId);
+
+  const handleGuildChange = (guildId: string) => {
+    setSelectedGuildId(guildId);
+    setSelectedChannelId("");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedGuildId || !selectedChannelId || !selectedStationId) return;
+    playMutation.mutate(
+      {
+        guildId: selectedGuildId,
+        input: { stationId: Number(selectedStationId), channelId: selectedChannelId },
+      },
+      {
+        onSuccess: () => {
+          setSelectedGuildId("");
+          setSelectedChannelId("");
+          setSelectedStationId("");
+        },
+      },
+    );
+  };
+
+  return (
+    <aside className="lg:col-span-1 sticky top-6">
+      <div className="bg-[#18181b] border border-zinc-800 rounded-lg p-6 lg:p-8 shadow-xl shadow-black/40">
+        <div className="flex items-center gap-3 mb-6 border-b border-zinc-800 pb-4">
+          <div className="p-2 bg-white text-black rounded">
+            <Play className="w-4 h-4" />
+          </div>
+          <h2 className="text-lg font-bold text-white tracking-tight">Quick Play</h2>
+        </div>
+
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="text-[10px] uppercase tracking-widest font-bold text-zinc-400">
+              Target Guild
+            </label>
+            <select
+              value={selectedGuildId}
+              onChange={(e) => handleGuildChange(e.target.value)}
+              className="w-full bg-black border border-zinc-700 rounded p-3 text-sm text-white focus:border-white focus:ring-0 transition-colors"
+            >
+              <option value="">Select Guild...</option>
+              {guilds.map((g) => (
+                <option key={g.guildId} value={g.guildId}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-[10px] uppercase tracking-widest font-bold text-zinc-400">
+              Voice Channel
+            </label>
+            <select
+              value={selectedChannelId}
+              onChange={(e) => setSelectedChannelId(e.target.value)}
+              disabled={!selectedGuildId}
+              className="w-full bg-black border border-zinc-700 rounded p-3 text-sm text-white focus:border-white focus:ring-0 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="">Select Channel...</option>
+              {selectedGuild?.voiceChannels.map((ch) => (
+                <option key={ch.id} value={ch.id}>
+                  {ch.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-[10px] uppercase tracking-widest font-bold text-zinc-400">
+              Radio Station
+            </label>
+            <select
+              value={selectedStationId}
+              onChange={(e) => setSelectedStationId(e.target.value)}
+              className="w-full bg-black border border-zinc-700 rounded p-3 text-sm text-white focus:border-white focus:ring-0 transition-colors"
+            >
+              <option value="">Select Station...</option>
+              {stations?.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="pt-4">
+            <button
+              type="submit"
+              disabled={
+                !selectedGuildId ||
+                !selectedChannelId ||
+                !selectedStationId ||
+                playMutation.isPending
+              }
+              className="w-full bg-white text-black hover:bg-zinc-200 transition-colors py-4 rounded font-bold uppercase tracking-widest shadow-lg shadow-white/5 hover:shadow-white/20 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Zap className="w-4 h-4" />
+              {playMutation.isPending ? "Starting..." : "Start Stream"}
+            </button>
+            <p className="text-[10px] text-zinc-600 mt-3 text-center">
+              By starting a stream, the bot will join the selected channel immediately.
+            </p>
+          </div>
+        </form>
+      </div>
+
+      <div className="mt-6 border border-red-900/30 rounded-lg p-4 bg-red-900/10">
+        <div className="flex items-center gap-2 mb-3">
+          <AlertTriangle className="w-3.5 h-3.5 text-red-500" />
+          <h4 className="text-xs font-bold text-red-400 uppercase tracking-widest">
+            Emergency Zone
+          </h4>
+        </div>
+        <p className="text-[10px] text-zinc-400 mb-4 leading-relaxed">
+          Instantly disconnect bot from all voice channels. Use only in case of issues.
+        </p>
+        <button
+          onClick={() => stopAllMutation.mutate()}
+          disabled={stopAllMutation.isPending}
+          className="w-full bg-red-500/10 hover:bg-red-500 text-red-500 hover:text-white border border-red-500/50 hover:border-red-500 transition-all px-4 py-2 rounded text-xs font-bold uppercase tracking-wide flex items-center justify-center gap-2 disabled:opacity-50"
+        >
+          <Square className="w-3.5 h-3.5" />
+          {stopAllMutation.isPending ? "Stopping..." : "Stop All Players"}
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function ConnectionsSkeleton() {
+  return (
+    <div className="space-y-6">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="bg-[#18181b] border border-zinc-800/50 rounded-lg p-5 flex flex-col sm:flex-row sm:items-center gap-5 opacity-40"
+        >
+          <Skeleton className="w-14 h-14 rounded-lg" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-1/3 rounded" />
+            <Skeleton className="h-3 w-1/2 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ControlsPage() {
+  const { data: guilds, isLoading } = useGuilds();
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const activeGuilds = useMemo(
+    () => (guilds ?? []).filter((g) => g.audio.isPlaying),
+    [guilds],
+  );
+
+  const filteredGuilds = useMemo(
+    () =>
+      activeGuilds.filter((g) => g.name.toLowerCase().includes(searchQuery.toLowerCase())),
+    [activeGuilds, searchQuery],
+  );
+
+  return (
+    <div className="space-y-0">
+      <header className="mb-8 flex flex-col md:flex-row md:items-center justify-between gap-6">
+        <div>
+          <h1 className="text-3xl font-bold text-white tracking-tight mb-2">
+            Playback Control Center
+          </h1>
+          <p className="text-zinc-400 text-sm">
+            Manage active voice connections and stream status.
+          </p>
+        </div>
+      </header>
+
+      {isLoading ? (
+        <>
+          <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-24 rounded-lg" />
+            ))}
+          </section>
+          <ConnectionsSkeleton />
+        </>
+      ) : (
+        <>
+          <StatsCards guilds={guilds ?? []} />
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
+            <section className="lg:col-span-2 space-y-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-sm font-bold text-white uppercase tracking-widest">
+                  Active Connections
+                </h2>
+                <div className="flex items-center gap-2">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
+                    <input
+                      type="text"
+                      placeholder="Search guild..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="bg-zinc-900 border border-zinc-800 text-white text-xs px-3 py-1.5 pl-8 rounded focus:border-zinc-500 focus:ring-0 placeholder-zinc-600 w-48"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {filteredGuilds.length === 0 ? (
+                <div className="bg-[#18181b] border border-zinc-800 rounded-lg p-12 text-center">
+                  <Radio className="w-8 h-8 text-zinc-600 mx-auto mb-3" />
+                  <p className="text-sm text-zinc-500">No active connections</p>
+                  <p className="text-xs text-zinc-600 mt-1">
+                    Use Quick Play to start a stream in a guild.
+                  </p>
+                </div>
+              ) : (
+                filteredGuilds.map((guild) => (
+                  <ActiveConnectionCard key={guild.guildId} guild={guild} />
+                ))
+              )}
+            </section>
+
+            <QuickPlaySidebar guilds={guilds ?? []} />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/dashboard/overview.tsx
+++ b/src/pages/dashboard/overview.tsx
@@ -1,10 +1,252 @@
-export default function DashboardPage() {
+import { useMemo } from "react";
+import { Link } from "react-router";
+import { Server, Headphones, Clock, Radio, Square, ArrowRight, AlertTriangle } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useHealth } from "@/hooks/use-health";
+import { useGuilds, useStopAll } from "@/hooks/use-guilds";
+import { formatUptime } from "@/lib/utils";
+import type { GuildStatus } from "@/types/api";
+
+function WaveformBars() {
   return (
-    <div className="space-y-4">
-      <h1 className="text-3xl font-bold">Dashboard</h1>
-      <p className="text-muted-foreground">
-        Overview of your lofi bot — stream status, listeners, and quick stats.
-      </p>
+    <div className="flex items-end gap-[2px] h-3">
+      <div
+        className="w-0.5 bg-emerald-500 rounded-sm animate-bounce"
+        style={{ animationDelay: "0.1s", height: "8px" }}
+      />
+      <div
+        className="w-0.5 bg-emerald-500 rounded-sm animate-bounce"
+        style={{ animationDelay: "0.3s", height: "12px" }}
+      />
+      <div
+        className="w-0.5 bg-emerald-500 rounded-sm animate-bounce"
+        style={{ animationDelay: "0.2s", height: "4px" }}
+      />
+    </div>
+  );
+}
+
+function TopStreamCard({ guild }: { guild: GuildStatus }) {
+  return (
+    <div className="group flex items-center gap-4 p-4 bg-zinc-900/50 hover:bg-zinc-900 border border-zinc-800 hover:border-zinc-600 rounded-lg transition-all">
+      <div className="relative w-12 h-12 rounded bg-zinc-800 overflow-hidden shrink-0 border border-zinc-700">
+        {guild.iconUrl ? (
+          <img
+            src={guild.iconUrl}
+            alt={guild.name}
+            className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-zinc-500 font-bold text-sm">
+            {guild.name
+              .split(/\s+/)
+              .slice(0, 2)
+              .map((w) => w[0])
+              .join("")
+              .toUpperCase()}
+          </div>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex justify-between items-center mb-1">
+          <h4 className="text-sm font-bold text-white truncate">{guild.name}</h4>
+          <div className="flex items-center gap-1">
+            <WaveformBars />
+            <span className="text-[10px] text-emerald-500 uppercase font-bold ml-1">Live</span>
+          </div>
+        </div>
+        <div className="flex justify-between items-center">
+          <p className="text-xs text-zinc-400 truncate">
+            Playing: {guild.audio.currentStation?.name ?? "Unknown"}
+          </p>
+          <span className="text-xs text-white bg-zinc-800 px-2 py-0.5 rounded">
+            {guild.audio.listenerCount} listeners
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  const { data: health, isLoading: healthLoading } = useHealth();
+  const { data: guilds, isLoading: guildsLoading } = useGuilds();
+  const stopAllMutation = useStopAll();
+
+  const isLoading = healthLoading || guildsLoading;
+
+  const activeGuilds = useMemo(
+    () =>
+      (guilds ?? [])
+        .filter((g) => g.audio.isPlaying)
+        .sort((a, b) => b.audio.listenerCount - a.audio.listenerCount),
+    [guilds],
+  );
+
+  const totalListeners = useMemo(
+    () => (guilds ?? []).reduce((sum, g) => sum + g.audio.listenerCount, 0),
+    [guilds],
+  );
+
+  const topStreams = activeGuilds.slice(0, 3);
+
+  return (
+    <div className="space-y-0">
+      <header className="mb-10 flex justify-between items-end">
+        <div>
+          <div className="inline-flex items-center gap-2 px-2 py-1 bg-zinc-900 rounded text-[10px] uppercase tracking-widest text-emerald-500 mb-2 border border-emerald-500/20">
+            <span className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse" />
+            {health?.status === "healthy" ? "System Operational" : "System Status Unknown"}
+          </div>
+          <h1 className="text-3xl font-bold text-white tracking-tight">Command Center</h1>
+          <p className="text-zinc-500 text-sm mt-1">Real-time bot metrics and controls.</p>
+        </div>
+      </header>
+
+      {isLoading ? (
+        <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-32 rounded-lg" />
+          ))}
+        </section>
+      ) : (
+        <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          <div className="bg-[#18181b] border border-zinc-800 p-6 rounded-lg hover:border-zinc-700 transition-all group relative overflow-hidden">
+            <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 transition-opacity">
+              <Server className="w-16 h-16 text-white" />
+            </div>
+            <h3 className="text-zinc-500 text-xs font-bold uppercase tracking-widest mb-2">
+              Connected Servers
+            </h3>
+            <div className="flex items-baseline gap-2">
+              <span className="text-4xl font-bold text-white tracking-tighter">
+                {health?.discord.guilds ?? 0}
+              </span>
+            </div>
+            <div className="w-full bg-zinc-800 h-1 rounded-full mt-4 overflow-hidden">
+              <div className="bg-white h-full w-[85%]" />
+            </div>
+          </div>
+
+          <div className="bg-[#18181b] border border-zinc-800 p-6 rounded-lg hover:border-zinc-700 transition-all group relative overflow-hidden">
+            <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 transition-opacity">
+              <Headphones className="w-16 h-16 text-white" />
+            </div>
+            <h3 className="text-zinc-500 text-xs font-bold uppercase tracking-widest mb-2">
+              Active Listeners
+            </h3>
+            <div className="flex items-baseline gap-2">
+              <span className="text-4xl font-bold text-white tracking-tighter">
+                {totalListeners.toLocaleString()}
+              </span>
+            </div>
+            <div className="w-full bg-zinc-800 h-1 rounded-full mt-4 overflow-hidden">
+              <div className="bg-emerald-500 h-full w-[65%]" />
+            </div>
+          </div>
+
+          <div className="bg-[#18181b] border border-zinc-800 p-6 rounded-lg hover:border-zinc-700 transition-all group relative overflow-hidden">
+            <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 transition-opacity">
+              <Clock className="w-16 h-16 text-white" />
+            </div>
+            <h3 className="text-zinc-500 text-xs font-bold uppercase tracking-widest mb-2">
+              System Uptime
+            </h3>
+            <div className="flex items-baseline gap-2">
+              <span className="text-4xl font-bold text-white tracking-tighter">
+                {health ? formatUptime(health.uptime) : "--"}
+              </span>
+            </div>
+            <div className="w-full bg-zinc-800 h-1 rounded-full mt-4 overflow-hidden">
+              <div className="bg-emerald-500 h-full w-[99%]" />
+            </div>
+          </div>
+        </section>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <section className="lg:col-span-2">
+          <div className="bg-[#18181b] border border-zinc-800 rounded-lg h-full flex flex-col">
+            <div className="p-6 border-b border-zinc-800 flex justify-between items-center">
+              <div className="flex items-center gap-3">
+                <Radio className="w-5 h-5 text-zinc-400" />
+                <h2 className="text-sm font-bold text-white uppercase tracking-widest">
+                  Top Active Streams
+                </h2>
+              </div>
+              <span className="text-[10px] text-zinc-500 uppercase tracking-widest border border-zinc-700 px-2 py-1 rounded bg-zinc-900">
+                Live Feed
+              </span>
+            </div>
+            <div className="p-6 space-y-4 flex-1">
+              {isLoading ? (
+                [1, 2, 3].map((i) => <Skeleton key={i} className="h-20 rounded-lg" />)
+              ) : topStreams.length === 0 ? (
+                <div className="text-center py-8">
+                  <Radio className="w-8 h-8 text-zinc-600 mx-auto mb-3" />
+                  <p className="text-sm text-zinc-500">No active streams</p>
+                </div>
+              ) : (
+                topStreams.map((guild) => (
+                  <TopStreamCard key={guild.guildId} guild={guild} />
+                ))
+              )}
+            </div>
+            <div className="p-4 border-t border-zinc-800">
+              <Link
+                to="/controls"
+                className="w-full py-2 text-xs font-bold text-zinc-500 uppercase hover:text-white transition-colors flex items-center justify-center gap-2"
+              >
+                View All Active Streams <ArrowRight className="w-3.5 h-3.5" />
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="lg:col-span-1">
+          <div className="bg-[#18181b] border border-zinc-800 rounded-lg h-full flex flex-col">
+            <div className="p-6 border-b border-zinc-800">
+              <div className="flex items-center gap-3">
+                <Radio className="w-5 h-5 text-zinc-400" />
+                <h2 className="text-sm font-bold text-white uppercase tracking-widest">
+                  Quick Controls
+                </h2>
+              </div>
+            </div>
+            <div className="p-6 space-y-6 flex-1">
+              <div className="p-4 rounded border border-red-900/30 bg-red-900/10">
+                <div className="flex items-center gap-2 mb-3">
+                  <AlertTriangle className="w-3.5 h-3.5 text-red-500" />
+                  <h4 className="text-xs font-bold text-red-400 uppercase tracking-widest">
+                    Emergency Zone
+                  </h4>
+                </div>
+                <p className="text-[10px] text-zinc-400 mb-4 leading-relaxed">
+                  Instantly disconnect bot from all voice channels. Use only in case of API rate
+                  limits or bugs.
+                </p>
+                <button
+                  onClick={() => stopAllMutation.mutate()}
+                  disabled={stopAllMutation.isPending}
+                  className="w-full bg-red-500/10 hover:bg-red-500 text-red-500 hover:text-white border border-red-500/50 hover:border-red-500 transition-all px-4 py-2 rounded text-xs font-bold uppercase tracking-wide flex items-center justify-center gap-2 disabled:opacity-50"
+                >
+                  <Square className="w-3.5 h-3.5" />
+                  {stopAllMutation.isPending ? "Stopping..." : "Stop All Players"}
+                </button>
+              </div>
+
+              <div className="pt-4 border-t border-zinc-800">
+                <Link
+                  to="/controls"
+                  className="block text-center p-3 bg-white text-black hover:bg-zinc-200 transition-colors rounded text-sm font-bold uppercase tracking-wide shadow-lg shadow-white/5"
+                >
+                  Open Full Controls
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/services/guild-service.ts
+++ b/src/services/guild-service.ts
@@ -1,0 +1,25 @@
+import { apiClient } from "@/lib/api-client";
+import type { GuildStatus, PlayInGuildInput } from "@/types/api";
+
+export function getGuilds(): Promise<GuildStatus[]> {
+  return apiClient<GuildStatus[]>("/api/guilds");
+}
+
+export function getGuildStatus(guildId: string): Promise<GuildStatus> {
+  return apiClient<GuildStatus>(`/api/guilds/${guildId}/status`);
+}
+
+export function playInGuild(guildId: string, input: PlayInGuildInput): Promise<GuildStatus> {
+  return apiClient<GuildStatus>(`/api/guilds/${guildId}/play`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function stopInGuild(guildId: string): Promise<void> {
+  return apiClient<void>(`/api/guilds/${guildId}/stop`, { method: "POST" });
+}
+
+export function stopAll(): Promise<void> {
+  return apiClient<void>("/api/guilds/stop-all", { method: "POST" });
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -58,3 +58,31 @@ export interface ApiErrorResponse {
   error: string;
   statusCode: number;
 }
+
+export interface GuildAudioState {
+  isPlaying: boolean;
+  currentStation: { id: number; name: string } | null;
+  channelId: string | null;
+  channelName: string | null;
+  listenerCount: number;
+  connectedSince: string | null;
+}
+
+export interface VoiceChannel {
+  id: string;
+  name: string;
+}
+
+export interface GuildStatus {
+  guildId: string;
+  name: string;
+  iconUrl: string | null;
+  memberCount: number;
+  audio: GuildAudioState;
+  voiceChannels: VoiceChannel[];
+}
+
+export interface PlayInGuildInput {
+  stationId: number;
+  channelId: string;
+}


### PR DESCRIPTION
## Summary

- Replace stub Controls page with full **Playback Control Center** — stats row, active connections list with search, Quick Play sidebar (guild/channel/station selectors), and Emergency Stop All
- Replace stub Overview page with **Command Center** — system status badge, stats cards, top 3 active streams with waveform animation, quick controls with Emergency Stop and link to full controls
- Add `guild-service.ts` (5 API functions), `use-guilds.ts` hook (React Query with 10s polling), and `GuildStatus`/`PlayInGuildInput` types
- Add `formatUptime()` utility in `lib/utils.ts`

Closes #7
Depends on: MeninoNias/lofi-bot#45

## Test plan

- [x] Run `npm run build` — verify clean build
- [x] Start dashboard with `npm run dev`, navigate to `/` — verify Command Center loads with stats and top streams
- [x] Navigate to `/controls` — verify Playback Control Center loads with guild list and Quick Play form
- [x] Test Quick Play: select guild → channel → station → Start Stream
- [x] Test Stop button on individual guild connections
- [x] Test Emergency Stop All button on both pages
- [x] Verify search filter works on active connections list
- [x] Verify skeleton loading states appear while data is fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)